### PR TITLE
Update Blesta version requirement to 5.11.0 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This development kit includes the following:
 ## Requirements
 
 * **PHP 8.1.0 or greater**
-* **Blesta 3.0.0 or greater**
+* **Blesta 5.11.0 or greater**
 * cURL extension
 
 ## Features


### PR DESCRIPTION
Changed minimum Blesta version from 3.0.0 to 5.11.0 to reflect the actual compatibility requirements for the modern API authentication headers and PHP 8.1+ support.